### PR TITLE
Search Page Pagination

### DIFF
--- a/search/app/main.py
+++ b/search/app/main.py
@@ -21,7 +21,7 @@ def read_root():
 
 
 @app.get("/search/")
-def search(query: str, size: int = 10):
+def search(query: str, size: int = 100):
     start = timer()
     hits = searcher.search(query, k=size)
     end = timer()
@@ -29,6 +29,7 @@ def search(query: str, size: int = 10):
     return {
         "query": query,
         "total_matches": len(hits),
+        "size": size,
         "total_time": total_time,
         "hits":
             [{

--- a/web/Web/web/interfaces/SearchEngine/anserini.py
+++ b/web/Web/web/interfaces/SearchEngine/anserini.py
@@ -8,12 +8,12 @@ from collections import OrderedDict
 class Anserini(SearchInterface):
 
     @staticmethod
-    def search(query: str, size: int):
+    def search(query: str, size: int =100):
         response = requests.get(
             f"http://{SEARCH_SERVER_IP}:{SEARCH_SERVER_PORT}/search",
             params={
                 "query": query,
-                "size": size
+                "size": size,
             }
         )
         response.raise_for_status()

--- a/web/Web/web/search/templates/search/search_list.html
+++ b/web/Web/web/search/templates/search/search_list.html
@@ -75,9 +75,8 @@
     </div>
   </div>
   {% endif %}
-{% endif %}
 
-<nav aria-label="...">
+<nav class="my-4">
   <ul class="pagination justify-content-center">
       <li class="page-item {{ pagination.is_first_page|yesno:'disabled,' }}">
       <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number=1">First</a>
@@ -102,3 +101,4 @@
 
   </ul>
 </nav>
+{% endif %}

--- a/web/Web/web/search/templates/search/search_list.html
+++ b/web/Web/web/search/templates/search/search_list.html
@@ -76,3 +76,29 @@
   </div>
   {% endif %}
 {% endif %}
+
+<nav aria-label="...">
+  <ul class="pagination justify-content-center">
+      <li class="page-item {{ pagination.is_first_page|yesno:'disabled,' }}">
+      <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number=1">First</a>
+    </li>
+    <li class="page-item {{ pagination.is_first_page|yesno:'disabled,' }}">
+      <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number={{pagination.page_number|add:-1}}">Prev</a>
+    </li>
+    {% for i in pagination.page_range %}
+    <li class="page-item {% if pagination.page_number == i %} active {% endif %}">
+      <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number={{i}}">
+        {{i}}
+        <span class="sr-only">(current)</span>
+      </a>
+    </li>
+    {% endfor %}
+    <li class="page-item {{ pagination.is_last_page|yesno:'disabled,' }}">
+        <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number={{pagination.page_number|add:+1}}">Next</a>
+    </li>
+    <li class="page-item {{ pagination.is_last_page|yesno:'disabled,' }}">
+        <a class="page-link" href="{% url 'search:query_result' query_id=queryID%}?page_number={{pagination.last_page}}">Last</a>
+    </li>
+
+  </ul>
+</nav>


### PR DESCRIPTION
So the way this works is we call the api and get 100 hits back and save them to the database. The `search:query_result` page now has a GET parameter `page_number`. Based on this parameter we only show a fraction of the hits  stored in the database.  