### PR TITLE
retain highlighted keyword search across documents

### DIFF
--- a/web/Web/web/CAL/templates/CAL/CAL.html
+++ b/web/Web/web/CAL/templates/CAL/CAL.html
@@ -193,6 +193,7 @@
 {% block extra_scripts %}
     <script src="{% static 'js/moment.min.js' %}"></script>
     <script src="https://unpkg.com/runtime-memcache@2.0.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script src="{% static 'js/document-viewer.js' %}"></script>
     <script src="{% static 'js/highlight.js' %}"></script>
 

--- a/web/Web/web/CAL/templates/CAL/CAL.html
+++ b/web/Web/web/CAL/templates/CAL/CAL.html
@@ -208,6 +208,11 @@
           fetchPreviouslyJudgedDocsOnInit: true,
           mainJudgingCriteriaName: '{% if main_judging_criteria_name %}{{ main_judging_criteria_name }}{% else %}Relevant{% endif %}',
           csrfmiddlewaretoken: "{{ csrf_token }}",
+
+          afterDocumentLoad: function (docid) {
+            // Perform keyword search if necessary
+            searchForKeyword();
+          }
         });
 
     </script>

--- a/web/Web/web/judgment/templates/judgment/judgments.html
+++ b/web/Web/web/judgment/templates/judgment/judgments.html
@@ -184,6 +184,11 @@
             $(`#doc_${docid}_judgment_badge`).attr('class', `badge ${newColor}`);
             $(`#doc_${docid}_judgment_badge`).text(relText);
             console.log(`badge ${newColor}`);
+          },
+
+          afterDocumentLoad: function (docid) {
+            // Perform keyword search if necessary
+            searchForKeyword();
           }
         });
 

--- a/web/Web/web/judgment/templates/judgment/judgments.html
+++ b/web/Web/web/judgment/templates/judgment/judgments.html
@@ -146,7 +146,9 @@
 {% block extra_scripts %}
     <script src="https://unpkg.com/runtime-memcache@2.0.0"></script>
     <script src="{% static 'js/moment.min.js' %}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script src="{% static 'js/document-viewer.js' %}"></script>
+    <script src="{% static 'js/highlight.js' %}"></script>
 
     <script>
 

--- a/web/Web/web/search/templates/search/search.html
+++ b/web/Web/web/search/templates/search/search.html
@@ -101,6 +101,11 @@
                 newColor = "#84c273"; break;
             }
             $(`#doc_${docid}_SERP_indicator`).attr('style', `border-color:${newColor}`);
+          },
+
+          afterDocumentLoad: function (docid) {
+            // Perform keyword search if necessary
+            searchForKeyword();
           }
         });
 

--- a/web/Web/web/search/templates/search/search.html
+++ b/web/Web/web/search/templates/search/search.html
@@ -61,6 +61,7 @@
     <script src="{% static 'js/mousetrap.min.js' %}"></script>
     <script src="https://unpkg.com/runtime-memcache@2.0.0"></script>
     <script src="{% static 'js/moment.min.js' %}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script src="{% static 'js/document-viewer.js' %}"></script>
     <script src="{% static 'js/highlight.js' %}"></script>
 

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -872,6 +872,11 @@ docView.prototype = {
         checkIfDocumentPreviouslyJudged(docid);
       }
 
+      let highlighted_keyword = Cookies.get('highlighted_keyword');
+      if (highlighted_keyword) {
+        $("#search_content").val(highlighted_keyword).trigger('input');
+      }
+
       parent.afterDocumentLoad(docid);
     }
 

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -872,11 +872,6 @@ docView.prototype = {
         checkIfDocumentPreviouslyJudged(docid);
       }
 
-      let highlighted_keyword = Cookies.get('highlighted_keyword');
-      if (highlighted_keyword) {
-        $("#search_content").val(highlighted_keyword).trigger('input');
-      }
-
       parent.afterDocumentLoad(docid);
     }
 

--- a/web/Web/web/static/js/highlight.js
+++ b/web/Web/web/static/js/highlight.js
@@ -179,7 +179,9 @@ $(function() {
    * specified context on input
    */
   $input.on("input", function() {
-  	var searchVal = this.value;
+    var searchVal = this.value;
+    // Store the keyword in Cookie
+    Cookies.set('highlighted_keyword', searchVal);
     $content.unmark({
       className: $className,
       done: function() {

--- a/web/Web/web/static/js/highlight.js
+++ b/web/Web/web/static/js/highlight.js
@@ -40,6 +40,14 @@ function update_highlighted_terms_view(){
 }
 
 
+function searchForKeyword() {
+  let highlighted_keyword = Cookies.get('highlighted_keyword');
+  if (highlighted_keyword) {
+    $("#search_content").val(highlighted_keyword).trigger('input');
+  }
+}
+
+
 $(function() {
 
   // the input field

--- a/web/Web/web/static/js/highlight.js
+++ b/web/Web/web/static/js/highlight.js
@@ -195,7 +195,7 @@ $(function() {
       done: function() {
         $content.mark(searchVal, {
           className: $className,
-          separateWordSearch: false,
+          separateWordSearch: true,
           exclude: $exclude,
           done: function() {
             updateMatchesDictionaries();

--- a/web/Web/web/static/js/highlight.js
+++ b/web/Web/web/static/js/highlight.js
@@ -195,7 +195,7 @@ $(function() {
       done: function() {
         $content.mark(searchVal, {
           className: $className,
-          separateWordSearch: true,
+          separateWordSearch: false,
           exclude: $exclude,
           done: function() {
             updateMatchesDictionaries();


### PR DESCRIPTION
Store the highlighted keyword in cookie to retain it across documents.
- Use js-cookie (https://www.npmjs.com/package/js-cookie)
- Cookie is cleared when browser (not tab) is closed (This is the default option. Expire time can be easily changed if necessary.)