### PR TITLE
add kibana reverse proxy route to nginx config

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -49,5 +49,8 @@ http {
             autoindex off;
             alias /data/para;
         }
+        location /kibana {
+            proxy_pass  http://127.0.0.1:5601/;
+        }
     }
 }


### PR DESCRIPTION
This minor edit adds the ability to have kibana monitoring with reverse proxy on nginx.