### PR TITLE
Added support for phrase search

### DIFF
--- a/web/Web/web/static/js/highlight.js
+++ b/web/Web/web/static/js/highlight.js
@@ -182,7 +182,8 @@ $(function() {
     marked_matches_counter = {};
   }
 
-  /** This function processes the entered keyword to support both
+  /** 
+   * This function processes the entered keyword to support both
    * phrase search (using double quotes) and seperate word search (seperated by space)
    * It takes advantage of the synonyms functionality in mark.js package
    * Sample input:


### PR DESCRIPTION
- Use double quotes for Phrase search
- Use space to separate individual keyword
- Support a mixture of phrase and separate words search

Example:
Phrase search:   "vitamin d"
Separate words search: coronavirus cure
Mixture: "vitamin d"  coronavirus cure