### PR TITLE
Finish Stratum before stopping even if budget exceeded

### DIFF
--- a/web/Web/web/CAL/views.py
+++ b/web/Web/web/CAL/views.py
@@ -3,7 +3,9 @@ import logging
 
 from braces import views
 from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 from django.http import JsonResponse
+from django.urls import reverse_lazy
 from django.views import generic
 from interfaces.DocumentSnippetEngine import functions as DocEngine
 
@@ -20,6 +22,8 @@ class CALHomePageView(views.LoginRequiredMixin,
     template_name = 'CAL/CAL.html'
 
     def get(self, request, *args, **kwargs):
+        if not self.request.user.current_session:
+            return HttpResponseRedirect(reverse_lazy('core:home'))
         return super(CALHomePageView, self).get(self, request, *args, **kwargs)
 
 

--- a/web/Web/web/core/models.py
+++ b/web/Web/web/core/models.py
@@ -24,7 +24,6 @@ class Session(models.Model):
 
     # max number of judgments you wish for this task. 0 or negative to have no max.
     max_number_of_judgments = models.IntegerField(null=False, blank=False)
-    stratum_docs_left = models.IntegerField(default=1, blank=True)
     strategy = models.CharField(max_length=64,
                                 choices=STRATEGY_CHOICES,
                                 null=False,

--- a/web/Web/web/core/models.py
+++ b/web/Web/web/core/models.py
@@ -24,6 +24,7 @@ class Session(models.Model):
 
     # max number of judgments you wish for this task. 0 or negative to have no max.
     max_number_of_judgments = models.IntegerField(null=False, blank=False)
+    stratum_docs_left = models.IntegerField(default=1, blank=True)
     strategy = models.CharField(max_length=64,
                                 choices=STRATEGY_CHOICES,
                                 null=False,

--- a/web/Web/web/core/session_utils.py
+++ b/web/Web/web/core/session_utils.py
@@ -26,7 +26,7 @@ def submit_new_predefined_topic_session_form(request):
                              messages.SUCCESS,
                              success_message)
     else:
-        print(form.errors)
+        messages.add_message(request, messages.ERROR, f'Ops! {form.errors}')
 
 
 def submit_new_session_form(request):

--- a/web/Web/web/core/session_utils.py
+++ b/web/Web/web/core/session_utils.py
@@ -25,6 +25,8 @@ def submit_new_predefined_topic_session_form(request):
         messages.add_message(request,
                              messages.SUCCESS,
                              success_message)
+    else:
+        print(form.errors)
 
 
 def submit_new_session_form(request):

--- a/web/Web/web/judgment/views.py
+++ b/web/Web/web/judgment/views.py
@@ -231,7 +231,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
             # Exit task only if number of judgments reached max (and maxjudged is enabled)
             if len(judgements) >= max_judged > 0 and (
                 'scal' not in self.request.user.current_session.strategy or
-                (is_from_cal and current_docview_stack_size <= 0)
+                (is_from_cal and current_docview_stack_size is not None and current_docview_stack_size <= 0)
             ):
                 self.request.user.current_session = None
                 self.request.user.save()

--- a/web/Web/web/judgment/views.py
+++ b/web/Web/web/judgment/views.py
@@ -237,7 +237,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
                 self.request.user.save()
 
                 message = 'You have judged >={} (max number of judgment you have ' \
-                          'specified for this task) documents.'.format(max_judged)
+                          'specified for this session) documents.'.format(max_judged)
                 messages.add_message(request,
                                      messages.SUCCESS,
                                      message)

--- a/web/Web/web/judgment/views.py
+++ b/web/Web/web/judgment/views.py
@@ -56,7 +56,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
             found_ctrl_f_terms_in_title = self.request_json.get(u"found_ctrl_f_terms_in_title", None)
             found_ctrl_f_terms_in_summary = self.request_json.get(u"found_ctrl_f_terms_in_summary", None)
             found_ctrl_f_terms_in_full_doc = self.request_json.get(u"found_ctrl_f_terms_in_full_doc", None)
-            len_docs = self.request_json.get(u"len_docs", None)
+            current_docview_stack_size = self.request_json.get(u"current_docview_stack_size", None)
         except KeyError:
             error_dict = {u"message": u"POST input missing important fields"}
 
@@ -167,7 +167,6 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
                                                                      seed_query,
                                                                      top_terms)
                 context[u"next_docs"] = documents
-
             except TimeoutError:
                 error_dict = {u"message": u"Timeout error. "
                                           u"Please check status of servers."}
@@ -232,7 +231,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
             # Exit task only if number of judgments reached max (and maxjudged is enabled)
             if len(judgements) >= max_judged > 0 and (
                 'scal' not in self.request.user.current_session.strategy or
-                (is_from_cal and len_docs <= 0)
+                (is_from_cal and current_docview_stack_size <= 0)
             ):
                 self.request.user.current_session = None
                 self.request.user.save()

--- a/web/Web/web/judgment/views.py
+++ b/web/Web/web/judgment/views.py
@@ -56,6 +56,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
             found_ctrl_f_terms_in_title = self.request_json.get(u"found_ctrl_f_terms_in_title", None)
             found_ctrl_f_terms_in_summary = self.request_json.get(u"found_ctrl_f_terms_in_summary", None)
             found_ctrl_f_terms_in_full_doc = self.request_json.get(u"found_ctrl_f_terms_in_full_doc", None)
+            len_docs = self.request_json.get(u"len_docs", None)
         except KeyError:
             error_dict = {u"message": u"POST input missing important fields"}
 
@@ -166,17 +167,6 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
                                                                      seed_query,
                                                                      top_terms)
                 context[u"next_docs"] = documents
-                judgements = Judgment.objects.filter(user=self.request.user,
-                                                     session=self.request.user.current_session).filter(
-                    relevance__isnull=False)
-                max_judged = self.request.user.current_session.max_number_of_judgments
-                if 'scal' in self.request.user.current_session.strategy:
-                    if len(judgements) < max_judged:
-                        self.request.user.current_session.stratum_docs_left = len(documents)
-                        self.request.user.current_session.save()
-                    else:
-                        self.request.user.current_session.stratum_docs_left -= 1
-                        self.request.user.current_session.save()
 
             except TimeoutError:
                 error_dict = {u"message": u"Timeout error. "
@@ -242,7 +232,7 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
             # Exit task only if number of judgments reached max (and maxjudged is enabled)
             if len(judgements) >= max_judged > 0 and (
                 'scal' not in self.request.user.current_session.strategy or
-                self.request.user.current_session.stratum_docs_left == 0
+                (is_from_cal and len_docs <= 0)
             ):
                 self.request.user.current_session = None
                 self.request.user.save()

--- a/web/Web/web/search/views.py
+++ b/web/Web/web/search/views.py
@@ -1,26 +1,25 @@
-import copy
-import math
-
-from config.settings.base import SEARCH_ENGINE
 from config.settings.base import DEFAULT_NUM_DISPLAY
-
+from config.settings.base import SEARCH_ENGINE
+import copy
 import json
 import logging
-from django.shortcuts import render
+import math
+
 from braces import views
-
 from django.http import HttpResponse
-
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse_lazy
 from django.utils.module_loading import import_string
 from django.views import generic
 
 from web.core.mixin import RetrievalMethodPermissionMixin
 from web.interfaces.DocumentSnippetEngine import functions as DocEngine
 from web.interfaces.SearchEngine.base import SearchInterface
+from web.search import helpers
 from web.search.models import Query
 from web.search.models import SearchResult
 from web.search.models import SERPClick
-from web.search import helpers
 
 SearchEngine: SearchInterface = import_string(SEARCH_ENGINE)
 logger = logging.getLogger(__name__)
@@ -63,6 +62,9 @@ class SimpleSearchView(views.LoginRequiredMixin,
         return page_number, num_display, offset
 
     def get(self, request, *args, **kwargs):
+        if not self.request.user.current_session:
+            return HttpResponseRedirect(reverse_lazy('core:home'))
+
         query = request.GET.get('query', None)
         if query:
             page_number, num_display, offset = self.get_params()

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -383,11 +383,16 @@ docView.prototype = {
 
     function showMaxJudgmentReached() {
       updateDocumentIndicator("",options.otherColor);
-      updateTitle("No more documents", {"font": options.secondaryTitleFont, "color": options.projectPrimaryColor});
-      updateMessage("There are no more documents to judge. Please wait or try refreshing the page.");
+      updateTitle("Max number of judgments reached", {"font": options.secondaryTitleFont, "color": options.projectPrimaryColor});
+      updateMessage("You have reached the max number of judgments for this session. You will be redirected to the home page shortly.");
       updateDocID(null);
       hideCloseButton();
       hideDocTab();
+
+      window.setTimeout(function(){
+        location.reload();
+      }, 5000);
+
     }
 
 

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -146,7 +146,7 @@ docView.prototype = {
       if ($(elm).data('is-serp-judging')){
         $(elm).on("click", function(){sendSERPJudgment($(elm).data("doc-id"), rel_val)});
       }else{
-        $(elm).on("click", function(){sendJudgment(rel_val, parent.viewStack.length, options.searchMode? null : refreshDocumentView)});
+        $(elm).on("click", function(){sendJudgment(rel_val, options.searchMode? null : refreshDocumentView)});
       }
     }
 
@@ -733,7 +733,8 @@ docView.prototype = {
 
     }
 
-    function sendJudgment(rel, len_docs, callback) {
+    function sendJudgment(rel, callback) {
+      var current_docview_stack_size = parent.viewStack.length;
       if (!(options.singleDocumentMode || options.searchMode)){
         window.scrollTo(0, 0);
       }
@@ -776,7 +777,7 @@ docView.prototype = {
           'ctrl_f_terms_input': $("#search_content").val(),
           'csrfmiddlewaretoken': options.csrfmiddlewaretoken,
           'page_title': document.title,
-          'len_docs': len_docs,
+          'current_docview_stack_size': current_docview_stack_size,
 
           // history item
           'historyItem': {

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -146,7 +146,7 @@ docView.prototype = {
       if ($(elm).data('is-serp-judging')){
         $(elm).on("click", function(){sendSERPJudgment($(elm).data("doc-id"), rel_val)});
       }else{
-        $(elm).on("click", function(){sendJudgment(rel_val, options.searchMode? null : refreshDocumentView)});
+        $(elm).on("click", function(){sendJudgment(rel_val, parent.viewStack.length, options.searchMode? null : refreshDocumentView)});
       }
     }
 
@@ -733,7 +733,7 @@ docView.prototype = {
 
     }
 
-    function sendJudgment(rel, callback) {
+    function sendJudgment(rel, len_docs, callback) {
       if (!(options.singleDocumentMode || options.searchMode)){
         window.scrollTo(0, 0);
       }
@@ -776,6 +776,7 @@ docView.prototype = {
           'ctrl_f_terms_input': $("#search_content").val(),
           'csrfmiddlewaretoken': options.csrfmiddlewaretoken,
           'page_title': document.title,
+          'len_docs': len_docs,
 
           // history item
           'historyItem': {


### PR DESCRIPTION
So I added an int to the session model to keep track of how many docs are left in the current stratum. For SCAL, the session will only terminate when both the stratum reaches zero and max judgments are exceeded. 