### PR TITLE
Show toast on judgment error

### DIFF
--- a/web/Web/web/CAL/templates/CAL/CAL.html
+++ b/web/Web/web/CAL/templates/CAL/CAL.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
 {% block pagetitle %}Discovery{% endblock %}
-{% block extra_head %}
-<link href="{% static 'css/loadawesome.css' %}" rel="stylesheet">
-{% endblock %}
 
 {% block navbar-form %}
 <form id="searchContentForm" class="form-inline my-2 my-lg-0 order-sm-1 order-md-3 align-self-center align-self-stretch">
@@ -209,6 +206,8 @@
   </div>
 </div>
 
+<!-- Discovery failed to recieve judgment toast -->
+{% include 'toasts/discovery_failed_to_recieve_judgment.html' %}
 <!-- Judging criteria modal -->
 {% include 'modals/additional_judging_criteria_modal.html' %}
 <!-- Keyboard shortcuts modal -->
@@ -243,7 +242,20 @@
           afterDocumentLoad: function (docid) {
             // Perform keyword search if necessary
             searchForKeyword();
+          },
+
+          afterCALFailedToRecieveJudgment: function(docid, rel) {
+            $('#toast_CALFailedToRecieveJudgment').toast('dispose');
+            $(".CALFailedToRecieveJudgmentSpinner").removeClass("d-none");
+            $("#CALFailedToRecieveJudgment_toast_body").addClass("d-none");
+            $("#toast_CALFailedToRecieveJudgment_docid").html(docid);
+            setInterval(function(){
+              $("#CALFailedToRecieveJudgment_toast_body").removeClass("d-none");
+              $(".CALFailedToRecieveJudgmentSpinner").addClass("d-none");
+            },500);
+            $('#toast_CALFailedToRecieveJudgment').toast('show');
           }
+
         });
 
     </script>

--- a/web/Web/web/interfaces/CAL/functions.py
+++ b/web/Web/web/interfaces/CAL/functions.py
@@ -20,7 +20,7 @@ def send_judgment(session, doc_id, rel, next_batch_size=5):
     :param next_batch_size:
     :return:
     """
-    h = httplib2.Http()
+    h = httplib2.Http(timeout=7)
     url = "http://{}:{}/CAL/judge"
 
     body = {'session_id': str(session),

--- a/web/Web/web/judgment/templates/judgment/judgments.html
+++ b/web/Web/web/judgment/templates/judgment/judgments.html
@@ -138,6 +138,8 @@
   {% include 'modals/document_modal.html' %}
   <!-- Judging criteria modal -->
   {% include 'modals/additional_judging_criteria_modal.html' %}
+  <!-- Discovery failed to recieve judgment toast -->
+  {% include 'toasts/discovery_failed_to_recieve_judgment.html' %}
 
 </div>
 
@@ -190,6 +192,18 @@
           afterDocumentLoad: function (docid) {
             // Perform keyword search if necessary
             searchForKeyword();
+          },
+
+          afterCALFailedToRecieveJudgment: function(docid, rel) {
+            $('#toast_CALFailedToRecieveJudgment').toast('dispose');
+            $(".CALFailedToRecieveJudgmentSpinner").removeClass("d-none");
+            $("#CALFailedToRecieveJudgment_toast_body").addClass("d-none");
+            $("#toast_CALFailedToRecieveJudgment_docid").html(docid);
+            setInterval(function(){
+              $("#CALFailedToRecieveJudgment_toast_body").removeClass("d-none");
+              $(".CALFailedToRecieveJudgmentSpinner").addClass("d-none");
+            },500);
+            $('#toast_CALFailedToRecieveJudgment').toast('show');
           }
         });
 

--- a/web/Web/web/judgment/views.py
+++ b/web/Web/web/judgment/views.py
@@ -168,12 +168,15 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
                                                                      top_terms)
                 context[u"next_docs"] = documents
             except TimeoutError:
+                context["CALFailedToRecieveJudgment"] = True
                 error_dict = {u"message": u"Timeout error. "
                                           u"Please check status of servers."}
                 return self.render_timeout_request_response(error_dict)
             except CALError as e:
+                context["CALFailedToRecieveJudgment"] = True
                 error_message = "CAL Exception: {}".format(str(e))
             except Exception as e:
+                context["CALFailedToRecieveJudgment"] = True
                 error_message = str(e)
 
         else:
@@ -181,15 +184,19 @@ class JudgmentAJAXView(views.CsrfExemptMixin, views.LoginRequiredMixin,
                 CALFunctions.send_judgment(self.request.user.current_session.uuid,
                                            doc_id,
                                            rel_CAL)
+
             except TimeoutError:
+                context["CALFailedToRecieveJudgment"] = True
                 traceback.print_exc()
                 error_dict = {u"message": u"Timeout error. "
                                           u"Please check status of servers."}
                 return self.render_timeout_request_response(error_dict)
             except CALError as e:
+                context["CALFailedToRecieveJudgment"] = True
                 traceback.print_exc()
                 error_message = "CAL Exception: {}".format(str(e))
             except Exception as e:
+                context["CALFailedToRecieveJudgment"] = True
                 traceback.print_exc()
                 error_message = str(e)
 

--- a/web/Web/web/search/templates/search/search.html
+++ b/web/Web/web/search/templates/search/search.html
@@ -51,6 +51,9 @@
 {% include 'modals/document_modal.html' %}
 <!-- Judging criteria modal -->
 {% include 'modals/additional_judging_criteria_modal.html' %}
+<!-- Discovery failed to recieve judgment toast -->
+{% include 'toasts/discovery_failed_to_recieve_judgment.html' %}
+
 
 {% endblock %}
 
@@ -105,6 +108,18 @@
           afterDocumentLoad: function (docid) {
             // Perform keyword search if necessary
             searchForKeyword();
+          },
+
+          afterCALFailedToRecieveJudgment: function(docid, rel) {
+            $('#toast_CALFailedToRecieveJudgment').toast('dispose');
+            $(".CALFailedToRecieveJudgmentSpinner").removeClass("d-none");
+            $("#CALFailedToRecieveJudgment_toast_body").addClass("d-none");
+            $("#toast_CALFailedToRecieveJudgment_docid").html(docid);
+            setInterval(function(){
+              $("#CALFailedToRecieveJudgment_toast_body").removeClass("d-none");
+              $(".CALFailedToRecieveJudgmentSpinner").addClass("d-none");
+            },500);
+            $('#toast_CALFailedToRecieveJudgment').toast('show');
           }
         });
 

--- a/web/Web/web/static/js/document-viewer.js
+++ b/web/Web/web/static/js/document-viewer.js
@@ -135,7 +135,7 @@ docView.prototype = {
     validateSelector(options.documentTabSelector, true, "documentTabSelector");
 
     // Don't touch these settings
-    var s = ["beforeDocumentLoad", "afterDocumentLoad", "afterDocumentJudge", "afterErrorShown"];
+    var s = ["beforeDocumentLoad", "afterDocumentLoad", "afterDocumentJudge", "afterErrorShown", "afterCALFailedToRecieveJudgment"];
 
     for (var k in s) {
       if (settings.hasOwnProperty(s[k])) {
@@ -759,6 +759,11 @@ docView.prototype = {
                   showMaxJudgmentReached();
                   return;
               }
+
+              if(result["CALFailedToRecieveJudgment"]){
+                parent.afterCALFailedToRecieveJudgment(docid, rel);
+              }
+
               parent.afterDocumentJudge(docid, rel);
           },
           error: function (result){
@@ -849,6 +854,10 @@ docView.prototype = {
                   showMaxJudgmentReached();
                   //disableJudgments();
                   return;
+              }
+
+              if(result["CALFailedToRecieveJudgment"]){
+                parent.afterCALFailedToRecieveJudgment(docid, rel);
               }
 
               if (parent.currentDocID === null){
@@ -1097,6 +1106,12 @@ docView.prototype = {
     "use strict";
     return this.triggerEvent("afterDocumentJudge", [docid, rel]);
   },
+
+  afterCALFailedToRecieveJudgment: function(docid, rel) {
+    "use strict";
+    return this.triggerEvent("afterCALFailedToRecieveJudgment", [docid, rel]);
+  },
+
 
   afterErrorShown: function () {
     "use strict";

--- a/web/Web/web/templates/base.html
+++ b/web/Web/web/templates/base.html
@@ -15,6 +15,7 @@
       <!-- Other -->
       <link href="{% static 'css/pace.css' %}" rel="stylesheet">
       <link href="{% static 'css/font-awesome-all.css' %}" rel="stylesheet">
+      <link href="{% static 'css/loadawesome.css' %}" rel="stylesheet">
       {% include "raven-config.html" %}
       <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}" type="image/x-icon">
       <link rel="icon" href="{% static 'images/favicon.ico' %}" type="image/x-icon">
@@ -37,6 +38,8 @@
           document.write(`<img alt="${input}" title="${input}" width=${width} height=${height} class="${css}" src="data:image/svg+xml;base64, ${svg} ">`);
         }
       </script>
+
+
       {% block extra_head %}{% endblock %}
 
   </head>
@@ -202,6 +205,8 @@
     <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
 
     <script>
+        // initilize toasts
+        $('.toast').toast()
 
         // Adds border-bottom to navbar when scroll
         $(window).scroll(function () {

--- a/web/Web/web/templates/toasts/discovery_failed_to_recieve_judgment.html
+++ b/web/Web/web/templates/toasts/discovery_failed_to_recieve_judgment.html
@@ -1,0 +1,20 @@
+<div id="toast_CALFailedToRecieveJudgment" class="toast mr-4 mt-5" style="position: fixed; top: 0; right: 0;z-index:100;" data-delay="4000">
+  <div class="toast-header">
+    <strong class="mr-auto text-danger">Ops!</strong>
+    <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">
+      <span>&times;</span>
+    </button>
+  </div>
+  <div class="toast-body d-flex flex-column" style="min-width: 260px;">
+    <!-- loader -->
+    <div class="mx-auto CALFailedToRecieveJudgmentSpinner my-3 d-none">
+      <div class="la-ball-circus text-secondary"><div></div><div></div><div></div><div></div><div></div></div>
+    </div>
+    <!-- end loader -->
+    <div id="CALFailedToRecieveJudgment_toast_body" class="d-none">
+      <p class="m-0">The discovery model was not able to</p>
+      <p class="m-0">recieve your judgment on docno: </p>
+      <p class="font-montserrat text-primary m-0 text-center" id="toast_CALFailedToRecieveJudgment_docid">hhi</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Shows an error toast when the discovery model fails to receive a judgment.

One way to test this is by having the CAL container stopped when making a judgment.