### PR TITLE
add hide class to toast

### DIFF
--- a/web/Web/web/templates/toasts/discovery_failed_to_receive_judgment.html
+++ b/web/Web/web/templates/toasts/discovery_failed_to_receive_judgment.html
@@ -1,4 +1,4 @@
-<div id="toast_CALFailedToReceiveJudgment" class="toast mr-" style="position: fixed; top: 0; right: 0;z-index:10; margin-top: 4rem!important;" data-delay="4000">
+<div id="toast_CALFailedToReceiveJudgment" class="toast hide mr-" style="position: fixed; top: 0; right: 0;z-index:10; margin-top: 4rem!important;" data-delay="4000">
   <div class="toast-header">
     <strong class="mr-auto text-danger">Ops!</strong>
     <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">
@@ -18,3 +18,4 @@
     </div>
   </div>
 </div>
+


### PR DESCRIPTION
So adding a hide class to the toast seems to have fixed the DOM bug where the toast is there but not visible.