### PR TITLE
Call restore function on session not found

### DIFF
--- a/web/Web/web/CAL/exceptions.py
+++ b/web/Web/web/CAL/exceptions.py
@@ -17,3 +17,15 @@ class CALServerError(CALError):
             msg = "An error occurred with CAL server. " \
                   "Returned status code {}.".format(status_code)
         super(CALServerError, self).__init__(msg)
+
+
+class CALServerSessionNotFoundError(CALError):
+    """
+    CAL server session not found error
+
+    """
+    def __init__(self, status_code, msg=None):
+        if msg is None:
+            msg = "Session is not found in CAL server. " \
+                  "Returned status code {}.".format(status_code)
+        super(CALServerError, self).__init__(msg)

--- a/web/Web/web/CAL/exceptions.py
+++ b/web/Web/web/CAL/exceptions.py
@@ -28,4 +28,4 @@ class CALServerSessionNotFoundError(CALError):
         if msg is None:
             msg = "Session is not found in CAL server. " \
                   "Returned status code {}.".format(status_code)
-        super(CALServerError, self).__init__(msg)
+        super(CALServerSessionNotFoundError, self).__init__(msg)

--- a/web/Web/web/CAL/views.py
+++ b/web/Web/web/CAL/views.py
@@ -115,6 +115,7 @@ class DocAJAXView(views.CsrfExemptMixin,
             error_dict = {u"message": u"Timeout error. Please check status of servers."}
             return self.render_timeout_request_response(error_dict)
         except CALServerSessionNotFoundError:
+            message = "Ops! Session is not found in CAL. "
             if "scal" not in self.request.user.current_session.strategy:
                 seed_judgments = Judgment.objects.filter(user=self.request.user,
                                                          session=session
@@ -124,8 +125,6 @@ class DocAJAXView(views.CsrfExemptMixin,
                                              seed_query,
                                              seed_judgments,
                                              strategy)
-            message = "Ops! Session is not found in CAL. "
-            if "scal" not in self.request.user.current_session.strategy:
                 message += "Restoring.. Please try in few minutes."
             return JsonResponse({"message": message}, status=404)
         except CALError as e:

--- a/web/Web/web/CAL/views.py
+++ b/web/Web/web/CAL/views.py
@@ -10,8 +10,10 @@ from django.views import generic
 from interfaces.DocumentSnippetEngine import functions as DocEngine
 
 from web.CAL.exceptions import CALError
+from web.CAL.exceptions import CALServerSessionNotFoundError
 from web.core.mixin import RetrievalMethodPermissionMixin
 from web.interfaces.CAL import functions as CALFunctions
+from web.judgment.models import Judgment
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +114,20 @@ class DocAJAXView(views.CsrfExemptMixin,
         except TimeoutError:
             error_dict = {u"message": u"Timeout error. Please check status of servers."}
             return self.render_timeout_request_response(error_dict)
+        except CALServerSessionNotFoundError:
+            if "scal" not in self.request.user.current_session.strategy:
+                seed_judgments = Judgment.objects.filter(user=self.request.user,
+                                                         session=session
+                                                         ).filter(relevance__isnull=False)
+                strategy = self.request.user.current_session.strategy
+                CALFunctions.restore_session(session,
+                                             seed_query,
+                                             seed_judgments,
+                                             strategy)
+            message = "Ops! Session is not found in CAL. "
+            if "scal" not in self.request.user.current_session.strategy:
+                message += "Restoring.. Please try in few minutes."
+            return JsonResponse({"message": message}, status=404)
         except CALError as e:
             return JsonResponse({"message": "Ops! CALError."}, status=404)
 
@@ -148,6 +164,7 @@ class SCALInfoView(views.CsrfExemptMixin,
             return self.render_timeout_request_response(error_dict)
         except CALError as e:
             return JsonResponse({"message": "Oops! CALError."}, status=404)
+
 
 class DocIDsAJAXView(views.CsrfExemptMixin,
                      RetrievalMethodPermissionMixin,

--- a/web/Web/web/CAL/views.py
+++ b/web/Web/web/CAL/views.py
@@ -80,10 +80,10 @@ class DocAJAXView(views.CsrfExemptMixin,
             json_context, content_type=self.get_content_type(), status=502)
 
     def get_ajax(self, request, *args, **kwargs):
-        session = self.request.user.current_session.uuid
+        session = self.request.user.current_session
         seed_query = self.request.user.current_session.topic.seed_query
         try:
-            docids_to_judge, top_terms = CALFunctions.get_documents(str(session), 10)
+            docids_to_judge, top_terms = CALFunctions.get_documents(str(session.uuid), 10)
             if not docids_to_judge:
                 return self.render_json_response([])
 
@@ -121,7 +121,7 @@ class DocAJAXView(views.CsrfExemptMixin,
                                                          session=session
                                                          ).filter(relevance__isnull=False)
                 strategy = self.request.user.current_session.strategy
-                CALFunctions.restore_session(session,
+                CALFunctions.restore_session(session.uuid,
                                              seed_query,
                                              seed_judgments,
                                              strategy)

--- a/web/Web/web/interfaces/CAL/functions.py
+++ b/web/Web/web/interfaces/CAL/functions.py
@@ -139,7 +139,7 @@ def get_documents(session, num_docs):
 
         return content['docs'], content['top-terms']
     elif resp and resp['status'] == '404':
-        raise CALServerSessionNotFoundError()
+        raise CALServerSessionNotFoundError(resp['status'])
     else:
         raise CALServerError(resp['status'])
 
@@ -154,6 +154,8 @@ def restore_session(session_id, seed_query, seed_documents, session_strategy):
     """
     url = f"http://{CAL_SERVER_IP}:{CAL_SERVER_PORT}/CAL/begin"
     seed_docs = ','.join([d.doc_id + ':' + str(d.relevance) for d in seed_documents])
+    print(seed_docs)
+    print(seed_documents)
 
     data = 'session_id={}&seed_query={}&seed_judgments={}&mode={}'.format(
         session_id, seed_query, seed_docs, session_strategy)

--- a/web/Web/web/interfaces/CAL/functions.py
+++ b/web/Web/web/interfaces/CAL/functions.py
@@ -154,8 +154,6 @@ def restore_session(session_id, seed_query, seed_documents, session_strategy):
     """
     url = f"http://{CAL_SERVER_IP}:{CAL_SERVER_PORT}/CAL/begin"
     seed_docs = ','.join([d.doc_id + ':' + str(d.relevance) for d in seed_documents])
-    print(seed_docs)
-    print(seed_documents)
 
     data = 'session_id={}&seed_query={}&seed_judgments={}&mode={}'.format(
         session_id, seed_query, seed_docs, session_strategy)

--- a/web/Web/web/interfaces/CAL/functions.py
+++ b/web/Web/web/interfaces/CAL/functions.py
@@ -145,8 +145,15 @@ def get_documents(session, num_docs):
 
 
 def restore_session(session_id, seed_query, seed_documents, session_strategy):
+    """
+    :param session_id:
+    :param seed_query:
+    :param seed_documents: Must be a queryset of the the model Judgment
+    :param session_strategy:
+    :return: request response
+    """
     url = f"http://{CAL_SERVER_IP}:{CAL_SERVER_PORT}/CAL/begin"
-    seed_docs = ','.join([doc_id + ':' + str(rel) for doc_id, rel in seed_documents])
+    seed_docs = ','.join([d.doc_id + ':' + str(d.relevance) for d in seed_documents])
 
     data = 'session_id={}&seed_query={}&seed_judgments={}&mode={}'.format(
         session_id, seed_query, seed_docs, session_strategy)


### PR DESCRIPTION
What this would do is automatically call a function to restore a session if the session is not found. An error message will be first shown when user enters the discovery interface for a session that is not loaded.  