### PR TITLE
DS seed judgements

### DIFF
--- a/CALEngine/src/bmi.cc
+++ b/CALEngine/src/bmi.cc
@@ -115,8 +115,13 @@ void BMI::add_to_training_cache(int id, int judgment){
 
 void BMI::record_judgment_batch(vector<pair<string, int>> _judgments){
     for(const auto &judgment: _judgments){
-        size_t id = documents->get_index(judgment.first);
-        add_to_training_cache(id, judgment.second);
+        auto doc_index = documents->get_index(judgment.first);
+        if (doc_index != documents->NPOS) {
+            size_t id = documents->get_index(judgment.first);
+            add_to_training_cache(id, judgment.second);
+        } else {
+            cerr << "Document with ID " << judgment.first << " not found" << endl;
+        }
     }
 
     if(!async_mode){

--- a/CALEngine/src/bmi_doc_scal.cc
+++ b/CALEngine/src/bmi_doc_scal.cc
@@ -14,7 +14,12 @@ BMI_doc_scal::BMI_doc_scal(Seed _seed,
     R = 0;
     judgments_per_iteration = B;
     for(auto &seed_judgment: seed_judgments){
-        add_to_training_cache(documents->get_index(seed_judgment.first), seed_judgment.second);
+        auto doc_index = documents->get_index(seed_judgment.first);
+        if (doc_index != documents->NPOS) {
+            add_to_training_cache(documents->get_index(seed_judgment.first), seed_judgment.second);
+        } else {
+            cerr << "Document with ID " << seed_judgment.first << " not found" << endl;
+        }
     }
     perform_iteration();
     stratums.push_back(vector<pair<int, float>>());

--- a/web/Web/web/core/forms.py
+++ b/web/Web/web/core/forms.py
@@ -83,6 +83,7 @@ class SessionForm(forms.ModelForm):
                                  required=True,
                                  help_text=SessionPredefinedTopicForm.Meta.help_texts.get('strategy'))
     show_full_document_content = forms.BooleanField(required=False)
+    judgments_file = forms.FileField(required=False, label='Optional seed judgments (csv file)')
 
     def __init__(self, *args, **kwargs):
         super(SessionForm, self).__init__(*args, **kwargs)
@@ -105,6 +106,7 @@ class SessionForm(forms.ModelForm):
                 css_class='d-none',
                 css_id="topic-show_full_document_content"
             ),
+            'judgments_file',
             StrictButton(u'Create session',
                          name=self.submit_name,
                          type="submit",

--- a/web/Web/web/core/models.py
+++ b/web/Web/web/core/models.py
@@ -42,16 +42,17 @@ class Session(models.Model):
                                       editable=False)
     updated_at = models.DateTimeField(auto_now=True)
 
-    def save(self, *args, **kwargs):
-        if not self.pk:
-            try:
-                CALFunctions.add_session(str(self.uuid),
-                                         self.topic.seed_query,
-                                         self.strategy)
-            except (CALError, ConnectionRefusedError, Exception) as e:
-                # TODO: log error
-                pass
-        super(Session, self).save(*args, **kwargs)
+    def begin_session_in_cal(self):
+        try:
+            judgments = self.judgment_set.all()
+            judgments_list = [(j.doc_id, j.relevance) for j in judgments]
+            CALFunctions.add_session(str(self.uuid),
+                                     self.topic.seed_query,
+                                     self.strategy,
+                                     judgments_list)
+        except (CALError, ConnectionRefusedError, Exception) as e:
+            # TODO: log error
+            pass
 
     def is_summary(self):
         return "para" in self.strategy

--- a/web/Web/web/core/session_utils.py
+++ b/web/Web/web/core/session_utils.py
@@ -1,11 +1,16 @@
+import csv
+import io
+
 from django.contrib import messages
 
 from web.CAL.exceptions import CALError
-from web.interfaces.CAL import functions as CALFunctions
 from web.core.forms import SessionForm
 from web.core.forms import SessionPredefinedTopicForm
 from web.core.models import Session
 from web.core.models import SharedSession
+from web.interfaces.CAL import functions as CALFunctions
+from web.interfaces.DocumentSnippetEngine import functions as DocEngine
+from web.judgment.models import Judgment
 from web.users.models import User
 
 NEW_SESSION_MESSAGE = 'Your session has been initialized and activated. ' \
@@ -27,6 +32,7 @@ def submit_new_predefined_topic_session_form(request):
                              success_message)
     else:
         messages.add_message(request, messages.ERROR, f'Ops! {form.errors}')
+    form.instance.begin_session_in_cal()
 
 
 def submit_new_session_form(request):
@@ -51,6 +57,68 @@ def submit_new_session_form(request):
                              success_message)
         request.user.current_session = session
         request.user.save()
+
+        if 'topic-judgments_file' in request.FILES:
+            judgments_dict, msg_type, msg = handle_judgments_file(request.FILES['topic-judgments_file'])
+
+            if judgments_dict:
+                Judgment.objects.bulk_create([
+                    Judgment(
+                        user=request.user,
+                        session=session,
+                        doc_id=doc_id,
+                        doc_title=doc_title,
+                        relevance=relevance,
+                        source="seed",
+                        historyVerbose=[{
+                            "username": request.user.username,
+                            "source": "seed",
+                            "judged": True,
+                            "relevance": relevance
+                        }]
+                    ) for doc_id, (doc_title, relevance) in judgments_dict.items()
+                ])
+                request.user.save()
+            elif msg_type == messages.ERROR:
+                msg += " Session deleted."
+                session.delete()
+            messages.add_message(request, msg_type, msg)
+
+        session.begin_session_in_cal()
+
+
+def handle_judgments_file(file):
+    try:
+        if not file.name.endswith('.csv'):
+            return None, messages.ERROR, 'Please upload a file ending with .csv extension.'
+
+        judgments_file = io.TextIOWrapper(file.file, encoding='utf-8')
+        io_string = io.StringIO(judgments_file.read())
+        reader = csv.DictReader(io_string)
+        judgments = []
+        for row in reader:
+            if row['docno'] is None or row['judgment'] is None:
+                return None, messages.ERROR, 'Please make sure you upload a valid csv file.'
+            else:
+                judgments.append((row['docno'], row['judgment']))
+
+        judgments_dict = dict()
+        for j in judgments:
+            doc = DocEngine.get_document_or_none(j[0])
+            if doc:
+                try:
+                    doc_title = doc['title']
+                    judgments_dict[j[0]] = (doc_title, Judgment.JudgingChoices(int(j[1])))
+                except ValueError:
+                    pass  # judgements with invalid relevance scores are ignored
+
+        return judgments_dict,\
+               messages.WARNING if len(judgments_dict) < len(judgments) else messages.SUCCESS,\
+               f"{len(judgments_dict)} out of {len(judgments)} seed judgments sent to CAL."
+    except IndexError:
+        return None, messages.ERROR, "Judgments file is incorrectly formatted."
+    except UnicodeDecodeError:
+        return None, messages.ERROR, "Judgments file has incorrect encoding."
 
 
 def activate_session_submit_form(request):
@@ -189,8 +257,6 @@ def revoke_shared_session_submit_form(request):
                              messages.ERROR,
                              message)
         return
-
-    return
 
 
 def delete_session_submit_form(request):

--- a/web/Web/web/core/session_utils.py
+++ b/web/Web/web/core/session_utils.py
@@ -104,8 +104,8 @@ def handle_judgments_file(file):
 
         judgments_dict = dict()
         for j in judgments:
-            doc = DocEngine.get_document_or_none(j[0])
-            if doc:
+            doc = DocEngine.get_documents([j[0]])[0]
+            if doc['ok']:
                 try:
                     doc_title = doc['title']
                     judgments_dict[j[0]] = (doc_title, Judgment.JudgingChoices(int(j[1])))

--- a/web/Web/web/interfaces/CAL/functions.py
+++ b/web/Web/web/interfaces/CAL/functions.py
@@ -1,11 +1,12 @@
-from config.settings.base import CAL_SERVER_IP
-from config.settings.base import CAL_SERVER_PORT
 import json
 import logging
 import urllib.parse
 
 import httplib2
+import requests
 
+from config.settings.base import CAL_SERVER_IP
+from config.settings.base import CAL_SERVER_PORT
 from web.CAL.exceptions import CALServerError
 
 logger = logging.getLogger(__name__)
@@ -65,32 +66,35 @@ def check_docid_exists(session, doc_id):
         raise CALServerError(resp['status'])
 
 
-def add_session(session, seed_query, mode):
+def add_session(session, seed_query, mode, seed_judgments = []):
     """
     Adds session to CAL backend server
     :param session:
     :param seed_query
     :param mode
     """
-    h = httplib2.Http()
-    url = "http://{}:{}/CAL/begin"
+    url = f"http://{CAL_SERVER_IP}:{CAL_SERVER_PORT}/CAL/begin"
 
     body = {'session_id': str(session),
             'seed_query': seed_query,
             'judgments_per_iteration': 1,
             'async': True,
-            'mode': mode}
-    post_body = '&'.join('%s=%s' % (k, v) for k, v in body.items())
+            'mode': mode,
+            }
 
-    resp, content = h.request(url.format(CAL_SERVER_IP,
-                                         CAL_SERVER_PORT),
-                              body=post_body,
-                              headers={'Content-Type': 'application/json; charset=UTF-8'},
-                              method="POST")
-    if resp and resp['status'] != '200':
-        return False
+    if seed_judgments:
+        body['seed_judgments']=','.join([j[0] + ':' + str(j[1]) for j in seed_judgments])
+
+    post_body = '&'.join('%s=%s' % (k, v) for k, v in body.items())
+    resp, content = response = requests.post(url,
+                                  data=post_body,
+                                  headers={'Content-Type': 'application/json; charset=UTF-8'},
+                                )
+
+    if resp.ok:
+        return True
     else:
-        raise CALServerError(resp['status'])
+        raise CALServerError(resp.status_code)
 
 
 def delete_session(session):

--- a/web/Web/web/interfaces/DocumentSnippetEngine/functions.py
+++ b/web/Web/web/interfaces/DocumentSnippetEngine/functions.py
@@ -1,7 +1,8 @@
+import httplib2
+import requests
+
 from config.settings.base import DOCUMENTS_URL
 from config.settings.base import PARA_URL
-
-import httplib2
 
 try:
     # For c speedups
@@ -61,6 +62,38 @@ def get_documents(doc_ids, query=None, top_terms=None, orig_para_id=None):
 
     return result
 
+
+
+def get_document_or_none(doc_id):
+    """
+    :param doc_id: the id of document to return
+    :return: documents content
+    """
+
+    url = f"{DOCUMENTS_URL}/{doc_id}"
+    resp = requests.get(url)
+    if not resp.ok:
+        return None
+
+    content = resp.content.decode('utf-8', 'ignore')
+    date = get_date(content)
+    title = get_subject(content)
+    if len(content) == 0:
+        if len(title) == 0:
+            title = '<i class="text-warning">The document title is empty</i>'
+        content = '<i class="text-warning">The document content is empty</i>'
+    else:
+        if len(title) == 0:
+            title = content[:32]
+
+    document = {
+        'doc_id': doc_id,
+        'title': title,
+        'content': content.replace("\n", "<br/>"),
+        'date': date,
+    }
+
+    return document
 
 def get_documents_with_snippet(doc_ids, query=None, top_terms=None):
     h = httplib2.Http()

--- a/web/Web/web/interfaces/DocumentSnippetEngine/functions.py
+++ b/web/Web/web/interfaces/DocumentSnippetEngine/functions.py
@@ -56,44 +56,14 @@ def get_documents(doc_ids, query=None, top_terms=None, orig_para_id=None):
             'title': title,
             'content': content.replace("\n", "<br/>"),
             'date': date,
-            'top_terms': top_terms.get(doc_id if orig_para_id is None else "{}.{}".format(doc_id, orig_para_id[idx]), None) if top_terms else None
+            'top_terms': top_terms.get(doc_id if orig_para_id is None else "{}.{}".format(doc_id, orig_para_id[idx]), None) if top_terms else None,
+            'ok': resp.status == 200
         }
         result.append(document)
 
     return result
 
 
-
-def get_document_or_none(doc_id):
-    """
-    :param doc_id: the id of document to return
-    :return: documents content
-    """
-
-    url = f"{DOCUMENTS_URL}/{doc_id}"
-    resp = requests.get(url)
-    if not resp.ok:
-        return None
-
-    content = resp.content.decode('utf-8', 'ignore')
-    date = get_date(content)
-    title = get_subject(content)
-    if len(content) == 0:
-        if len(title) == 0:
-            title = '<i class="text-warning">The document title is empty</i>'
-        content = '<i class="text-warning">The document content is empty</i>'
-    else:
-        if len(title) == 0:
-            title = content[:32]
-
-    document = {
-        'doc_id': doc_id,
-        'title': title,
-        'content': content.replace("\n", "<br/>"),
-        'date': date,
-    }
-
-    return document
 
 def get_documents_with_snippet(doc_ids, query=None, top_terms=None):
     h = httplib2.Http()

--- a/web/Web/web/interfaces/SearchEngine/anserini.py
+++ b/web/Web/web/interfaces/SearchEngine/anserini.py
@@ -1,4 +1,5 @@
 import requests
+
 from config.settings.base import DEFAULT_NUM_DISPLAY
 from config.settings.base import SEARCH_SERVER_IP
 from config.settings.base import SEARCH_SERVER_PORT

--- a/web/Web/web/interfaces/SearchEngine/elastic.py
+++ b/web/Web/web/interfaces/SearchEngine/elastic.py
@@ -1,6 +1,7 @@
 import json
 
 import requests
+
 from config.settings.base import DEFAULT_NUM_DISPLAY
 from config.settings.base import INDEX_NAME
 from config.settings.base import SEARCH_SERVER_IP

--- a/web/Web/web/templates/cards/sessions/create_sessions_card.html
+++ b/web/Web/web/templates/cards/sessions/create_sessions_card.html
@@ -12,7 +12,7 @@
   <div class="tab-pane fade active show" id="pills-custom-topic" role="tabpanel">
     <div class="row">
       <div class="col-md-12 mt-3">
-            <form method="POST">
+            <form method="POST" enctype="multipart/form-data">
             {% csrf_token %}
             {% crispy form_custom %}
             </form>

--- a/web/Web/web/templates/modals/create_session_modal.html
+++ b/web/Web/web/templates/modals/create_session_modal.html
@@ -32,7 +32,7 @@
           <div class="tab-pane fade active show" id="pills-custom-topic" role="tabpanel">
             <div class="row">
               <div class="col-md-12 mt-3">
-                    <form method="POST" action="{% url 'core:home' %}">
+                    <form method="POST" action="{% url 'core:home' %} " enctype="multipart/form-data">
                     {% csrf_token %}
                     {% crispy form_custom %}
                     </form>


### PR DESCRIPTION
There is now an option to add a judgments file when creating a custom session.

The biggest potential breaking change is that sessions are no longer sent to CAL when you save the session object. You have to call a `begin_session_in_cal` function on the session object. I added the function to the end of the `submit_new_predefined_topic_session_form` and `submit_new_session_form`  functions in session_utils.py but I'm not sure if it's needed anywhere else.