### PR TITLE
Fix slow seed judgment reads

### DIFF
--- a/CALEngine/src/bmi.cc
+++ b/CALEngine/src/bmi.cc
@@ -115,12 +115,11 @@ void BMI::add_to_training_cache(int id, int judgment){
 
 void BMI::record_judgment_batch(vector<pair<string, int>> _judgments){
     for(const auto &judgment: _judgments){
-        auto doc_index = documents->get_index(judgment.first);
-        if (doc_index != documents->NPOS) {
-            size_t id = documents->get_index(judgment.first);
+        size_t id = documents->get_index(judgment.first);
+        if (id != documents->NPOS) {
             add_to_training_cache(id, judgment.second);
         } else {
-            cerr << "Document with ID " << judgment.first << " not found" << endl;
+            cerr << "Document with ID " << judgment.first << " not found." << endl;
         }
     }
 

--- a/CALEngine/src/bmi_doc_scal.cc
+++ b/CALEngine/src/bmi_doc_scal.cc
@@ -18,7 +18,7 @@ BMI_doc_scal::BMI_doc_scal(Seed _seed,
         if (doc_index != documents->NPOS) {
             add_to_training_cache(documents->get_index(seed_judgment.first), seed_judgment.second);
         } else {
-            cerr << "Document with ID " << seed_judgment.first << " not found" << endl;
+            cerr << "Document with ID " << seed_judgment.first << " not found." << endl;
         }
     }
     perform_iteration();
@@ -32,13 +32,17 @@ void BMI_doc_scal::record_judgment_batch(vector<pair<string, int>> _judgments){
     lock_guard<mutex> lock(judgment_list_mutex);
     for(const auto &judgment: _judgments){
         size_t id = documents->get_index(judgment.first);
-        add_to_training_cache(id, judgment.second);
-        for(int i = (int)judgment_queue.size() - 1; i >= 0; i--){
-            if(judgment_queue[i].first == id){
-                judgment_queue.erase(judgment_queue.begin() + i);
-                if(judgment.second > 0) R++;
-                break;
+        if (id != documents->NPOS) {
+            add_to_training_cache(id, judgment.second);
+            for(int i = (int)judgment_queue.size() - 1; i >= 0; i--){
+                if(judgment_queue[i].first == id){
+                    judgment_queue.erase(judgment_queue.begin() + i);
+                    if(judgment.second > 0) R++;
+                    break;
+                }
             }
+        } else {
+            cerr << "Document with ID " << judgment.first << " not found." << endl;
         }
     }
 

--- a/web/Web/web/core/session_utils.py
+++ b/web/Web/web/core/session_utils.py
@@ -67,7 +67,7 @@ def submit_new_session_form(request):
                         user=request.user,
                         session=session,
                         doc_id=doc_id,
-                        doc_title=doc_title,
+                        doc_title="N/A",
                         relevance=relevance,
                         source="seed",
                         historyVerbose=[{
@@ -76,7 +76,7 @@ def submit_new_session_form(request):
                             "judged": True,
                             "relevance": relevance
                         }]
-                    ) for doc_id, (doc_title, relevance) in judgments_dict.items()
+                    ) for doc_id, relevance in judgments_dict.items()
                 ])
                 request.user.save()
             elif msg_type == messages.ERROR:
@@ -104,13 +104,10 @@ def handle_judgments_file(file):
 
         judgments_dict = dict()
         for j in judgments:
-            doc = DocEngine.get_documents([j[0]])[0]
-            if doc['ok']:
-                try:
-                    doc_title = doc['title']
-                    judgments_dict[j[0]] = (doc_title, Judgment.JudgingChoices(int(j[1])))
-                except ValueError:
-                    pass  # judgements with invalid relevance scores are ignored
+            try:
+                judgments_dict[j[0]] = Judgment.JudgingChoices(int(j[1]))
+            except ValueError:
+                pass  # judgements with invalid relevance scores are ignored
 
         return judgments_dict,\
                messages.WARNING if len(judgments_dict) < len(judgments) else messages.SUCCESS,\


### PR DESCRIPTION
When uploading seed judgment files, we no longer check if the doc exists or what the title is.
I had added a check for missing docs in CAL, and since docs are kept in memory, it should be faster.
Downside is seed judgments will no longer have titles in the DB.