### PR TITLE
Fix premession denied error while building postgres container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
       context: ./web/Web
       dockerfile: ./compose/production/postgres/Dockerfile
     volumes:
-      - ./postgres_data_local:/var/lib/postgresql/data
-      - ./postgres_backup_local:/backups
+      - /postgres_data_local:/var/lib/postgresql/data
+      - /postgres_backup_local:/backups
     environment:
       - POSTGRES_USER=web
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
@AVakiliT I'm reverting back to how it was before. I tried rebuilding a fresh postgres container on mac and it kept failing to build. 